### PR TITLE
Update controller.dart

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -434,7 +434,7 @@ class PlPlayerController {
           configuration: PlayerConfiguration(
             // 默认缓存 5M 大小
             bufferSize:
-                videoType.value == 'live' ? 32 * 1024 * 1024 : 5 * 1024 * 1024,
+                videoType.value == 'live' ? 5 * 1024 * 1024 : 5 * 1024 * 1024,
           ),
         );
 


### PR DESCRIPTION
修改自原版1.0.19+141

降低直播缓存，由32M到5M。
上一版降低了直播清晰度，由原画到流畅。这些都是尝试延长直播时间，以免过早停止而无法继续播放。上一版试了个直播，时间达到30分钟，或许有些改善？清晰度还是可以的。
这一版还在测试，也许大幅改善了，但也降低了低信号时直播的稳定性。所以中断时，可以尝试返回再进入。
原版还是更好的，因为能更新。我这个版固定版本号，更新检测依然是官方版的，但不能覆盖安装，所以请不要开启。我的版本可以降级安装。